### PR TITLE
Make `.gitconfig` `email` and `name` RegExp stricter

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -73,7 +73,7 @@ module.exports = function(options) {
       if (err) { return cb(err); }
 
       _.each(data.split('\n'), function(line) {
-        if (/email/g.test(line) || /name/g.test(line)) {
+        if (/^\s*email\s*=/g.test(line) || /^\s*name\s*=/g.test(line)) {
           var parts = line.split('=');
           user[parts[0].trim()] = parts[1].trim();
         }


### PR DESCRIPTION
My `.gitconfig` included `[sendemail]` line, which matched `/email/`
RegExp, but didn't contain a valid configuration value.
